### PR TITLE
v0.9.6-alpha.1 — Live risk hardening and release metadata bump

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -105,6 +105,6 @@ jobs:
           prerelease: true
           files: artifacts/*.json
           body: |
-            v0.9.2-alpha.1 is an operational readiness and audit hardening alpha release. It adds live trading audit export, persistent Binance testnet certification reports, local backup/restore/reset/seed scripts, database migration baseline, diagnostics bundle collection, readiness dashboard details, dependency and secret scanning visibility, and GitHub release/safety templates.
+            v0.9.6-alpha.1 is a live risk hardening and release evidence alpha release. It aligns release metadata, strengthens live-order pre-submit guards for portfolio exposure, daily notional, realized loss, market-data staleness, and slippage, and keeps diagnostics/release artifacts auditable.
 
-            Real order submission remains disabled by default. Testnet certification reports are not production exchange certification, and this is not a production live trading release.
+            Real order submission remains disabled by default. Live risk guards and testnet/backtest validation are not production exchange certification, and this is not a production live trading release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.9.6-alpha.1] - 2026-06-03
+
+### Live Risk Hardening & Release Evidence
+
+### Added
+- Portfolio exposure, daily notional, realized-loss, slippage, and market-data staleness guards for live orders.
+- Live risk status exposure summary for synced positions, open orders, accepted daily notional, realized loss, and configured guard thresholds.
+- Release notes and checklist updates for `v0.9.6-alpha.1`.
+
+### Changed
+- Aligned monorepo, frontend, Java, Python, diagnostics scripts, and smoke-test version metadata to `0.9.6-alpha.1`.
+- Updated alpha release workflow copy for the current release scope.
+
+### Safety Notes
+- Real order submission remains disabled by default.
+- Live risk guards do not certify production exchange trading.
+- Testnet/backtest validation remains separate from production readiness.
+
+---
+
 ## [0.9.5-alpha.1] - 2026-05-30
 
 ### Backtest Diagnostics & Strategy Report

--- a/backend/java/pom.xml
+++ b/backend/java/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.example</groupId>
     <artifactId>TradeLab</artifactId>
-    <version>0.9.5-alpha.1</version>
+    <version>0.9.6-alpha.1</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/backend/java/src/main/java/com/example/back/livetrading/config/LiveTradingProperties.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/config/LiveTradingProperties.java
@@ -10,6 +10,9 @@ public record LiveTradingProperties(
         BigDecimal defaultMaxOrderNotional,
         BigDecimal defaultMaxPositionNotional,
         BigDecimal defaultMaxDailyNotional,
+        BigDecimal defaultMaxDailyLossNotional,
+        BigDecimal maxAllowedSlippagePercent,
+        long maxMarketDataAgeSeconds,
         int maxFailedOrdersBeforeCircuitBreaker,
         int maxRejectedOrdersBeforeCircuitBreaker,
         Binance binance
@@ -27,6 +30,15 @@ public record LiveTradingProperties(
         }
         if (defaultMaxDailyNotional == null) {
             defaultMaxDailyNotional = new BigDecimal("1000.00000000");
+        }
+        if (defaultMaxDailyLossNotional == null) {
+            defaultMaxDailyLossNotional = new BigDecimal("250.00000000");
+        }
+        if (maxAllowedSlippagePercent == null) {
+            maxAllowedSlippagePercent = new BigDecimal("2.00000000");
+        }
+        if (maxMarketDataAgeSeconds <= 0) {
+            maxMarketDataAgeSeconds = 60;
         }
         if (maxFailedOrdersBeforeCircuitBreaker <= 0) {
             maxFailedOrdersBeforeCircuitBreaker = 3;

--- a/backend/java/src/main/java/com/example/back/livetrading/dto/LiveRiskStatusResponse.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/dto/LiveRiskStatusResponse.java
@@ -1,5 +1,6 @@
 package com.example.back.livetrading.dto;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
@@ -7,6 +8,13 @@ public record LiveRiskStatusResponse(
         boolean killSwitchActive,
         String killSwitchReason,
         Instant killSwitchActivatedAt,
-        List<CircuitBreakerResponse> circuitBreakers
+        List<CircuitBreakerResponse> circuitBreakers,
+        BigDecimal syncedPositionExposure,
+        BigDecimal openOrderExposure,
+        BigDecimal acceptedDailyNotional,
+        BigDecimal realizedIntradayLoss,
+        BigDecimal maxAllowedDailyLoss,
+        BigDecimal maxAllowedSlippagePercent,
+        long maxMarketDataAgeSeconds
 ) {
 }

--- a/backend/java/src/main/java/com/example/back/livetrading/repository/LiveOrderRepository.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/repository/LiveOrderRepository.java
@@ -4,6 +4,7 @@ import com.example.back.livetrading.entity.LiveOrderEntity;
 import com.example.back.livetrading.entity.LiveOrderSide;
 import com.example.back.livetrading.entity.LiveOrderStatus;
 import com.example.back.livetrading.entity.LiveOrderType;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -27,4 +28,14 @@ public interface LiveOrderRepository extends JpaRepository<LiveOrderEntity, Long
     );
 
     long countByUserIdAndExchangeAndStatus(Long userId, String exchange, LiveOrderStatus status);
+
+    List<LiveOrderEntity> findAllByUserIdAndExchangeAndStatusIn(Long userId, String exchange, Collection<LiveOrderStatus> statuses);
+
+    List<LiveOrderEntity> findAllByUserIdAndSessionIdAndStatusInAndCreatedAtGreaterThanEqual(
+            Long userId,
+            Long sessionId,
+            Collection<LiveOrderStatus> statuses,
+            Instant createdAt
+    );
 }
+

--- a/backend/java/src/main/java/com/example/back/livetrading/repository/LivePositionRepository.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/repository/LivePositionRepository.java
@@ -10,4 +10,7 @@ public interface LivePositionRepository extends JpaRepository<LivePositionEntity
     List<LivePositionEntity> findAllByUserIdOrderByExchangeAscSymbolAsc(Long userId);
 
     Optional<LivePositionEntity> findByUserIdAndExchangeAndSymbol(Long userId, String exchange, String symbol);
+
+    List<LivePositionEntity> findAllByUserIdAndExchange(Long userId, String exchange);
 }
+

--- a/backend/java/src/main/java/com/example/back/livetrading/service/ExchangePriceSnapshot.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/service/ExchangePriceSnapshot.java
@@ -1,0 +1,10 @@
+package com.example.back.livetrading.service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record ExchangePriceSnapshot(
+        BigDecimal price,
+        Instant observedAt
+) {
+}

--- a/backend/java/src/main/java/com/example/back/livetrading/service/LiveExchangeAdapter.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/service/LiveExchangeAdapter.java
@@ -1,6 +1,7 @@
 package com.example.back.livetrading.service;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,6 +10,10 @@ public interface LiveExchangeAdapter {
     String exchange();
 
     Optional<BigDecimal> getLatestPrice(String symbol);
+
+    default Optional<ExchangePriceSnapshot> getLatestPriceSnapshot(String symbol) {
+        return getLatestPrice(symbol).map(price -> new ExchangePriceSnapshot(price, Instant.now()));
+    }
 
     LiveOrderResult placeOrder(LiveOrderRequest orderRequest, ExchangeCredentials credentials);
 

--- a/backend/java/src/main/java/com/example/back/livetrading/service/LiveTradingService.java
+++ b/backend/java/src/main/java/com/example/back/livetrading/service/LiveTradingService.java
@@ -43,7 +43,10 @@ import com.example.back.livetrading.repository.LiveTradingSessionRepository;
 import com.example.back.livetrading.repository.TestnetCertificationReportRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +70,12 @@ public class LiveTradingService {
             LiveOrderStatus.SUBMITTED,
             LiveOrderStatus.ACCEPTED,
             LiveOrderStatus.PARTIALLY_FILLED
+    );
+    private static final Set<LiveOrderStatus> DAILY_NOTIONAL_STATUSES = Set.of(
+            LiveOrderStatus.SUBMITTED,
+            LiveOrderStatus.ACCEPTED,
+            LiveOrderStatus.PARTIALLY_FILLED,
+            LiveOrderStatus.FILLED
     );
 
     private final LiveTradingProperties properties;
@@ -287,7 +296,14 @@ public class LiveTradingService {
                 killSwitch == null ? null : killSwitch.getActivatedAt(),
                 circuitBreakerRepository.findAllByUserIdOrderByUpdatedAtDesc(userId).stream()
                         .map(mapper::toCircuitBreakerResponse)
-                        .toList()
+                        .toList(),
+                scale(totalSyncedPositionExposure(userId, null)),
+                scale(totalOpenOrderExposure(userId, null)),
+                scale(totalAcceptedDailyNotional(userId, null)),
+                scale(totalRealizedIntradayLoss(userId, null)),
+                properties.defaultMaxDailyLossNotional(),
+                properties.maxAllowedSlippagePercent(),
+                properties.maxMarketDataAgeSeconds()
         );
     }
 
@@ -567,18 +583,46 @@ public class LiveTradingService {
                 && !List.of(session.getSymbolWhitelist().split(",")).contains(order.getSymbol())) {
             return "Symbol is not whitelisted for live trading";
         }
-        BigDecimal price = order.getType() == LiveOrderType.LIMIT
-                ? order.getRequestedPrice()
-                : adapter.getLatestPrice(order.getSymbol()).orElse(null);
-        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
+        ExchangePriceSnapshot priceSnapshot = adapter.getLatestPriceSnapshot(order.getSymbol()).orElse(null);
+        if (priceSnapshot == null || priceSnapshot.price() == null || priceSnapshot.price().compareTo(BigDecimal.ZERO) <= 0) {
             return "Latest market price is unavailable";
         }
-        BigDecimal notional = scale(order.getQuantity().multiply(price));
+        if (priceSnapshot.observedAt() == null || Duration.between(priceSnapshot.observedAt(), Instant.now())
+                .compareTo(Duration.ofSeconds(properties.maxMarketDataAgeSeconds())) > 0) {
+            return "Market data is stale for symbol " + order.getSymbol();
+        }
+        BigDecimal marketPrice = priceSnapshot.price();
+        BigDecimal riskPrice = order.getType() == LiveOrderType.LIMIT ? order.getRequestedPrice() : marketPrice;
+        if (order.getType() == LiveOrderType.MARKET && order.getRequestedPrice() == null) {
+            order.setRequestedPrice(scale(marketPrice));
+        }
+        if (order.getType() == LiveOrderType.LIMIT) {
+            BigDecimal slippagePercent = order.getRequestedPrice()
+                    .subtract(marketPrice)
+                    .abs()
+                    .multiply(new BigDecimal("100"))
+                    .divide(marketPrice, MONEY_SCALE, RoundingMode.HALF_UP);
+            if (slippagePercent.compareTo(properties.maxAllowedSlippagePercent()) > 0) {
+                return "Limit price exceeds max slippage percent " + properties.maxAllowedSlippagePercent();
+            }
+        }
+        BigDecimal notional = scale(order.getQuantity().multiply(riskPrice));
         if (notional.compareTo(session.getMaxOrderNotional()) > 0) {
             return "Order notional exceeds session max order limit " + session.getMaxOrderNotional();
         }
-        if (notional.compareTo(session.getMaxPositionNotional()) > 0) {
-            return "Order would exceed max position limit " + session.getMaxPositionNotional();
+        BigDecimal projectedExposure = totalSyncedPositionExposure(session.getUserId(), session.getExchange())
+                .add(totalOpenOrderExposure(session.getUserId(), session.getExchange()))
+                .add(notional);
+        if (projectedExposure.compareTo(session.getMaxPositionNotional()) > 0) {
+            return "Portfolio exposure would exceed max position limit " + session.getMaxPositionNotional();
+        }
+        BigDecimal projectedDailyNotional = totalAcceptedDailyNotional(session.getUserId(), session.getId()).add(notional);
+        if (projectedDailyNotional.compareTo(session.getMaxDailyNotional()) > 0) {
+            return "Daily notional would exceed session max daily limit " + session.getMaxDailyNotional();
+        }
+        BigDecimal realizedIntradayLoss = totalRealizedIntradayLoss(session.getUserId(), session.getExchange());
+        if (realizedIntradayLoss.compareTo(properties.defaultMaxDailyLossNotional()) > 0) {
+            return "Realized intraday loss exceeds configured limit " + properties.defaultMaxDailyLossNotional();
         }
         if (orderRepository.existsByUserIdAndExchangeAndSymbolAndSideAndTypeAndQuantityAndStatusInAndIdNot(
                 order.getUserId(), order.getExchange(), order.getSymbol(), order.getSide(), order.getType(),
@@ -597,6 +641,59 @@ public class LiveTradingService {
             }
         }
         return null;
+    }
+
+    private BigDecimal totalSyncedPositionExposure(Long userId, String exchange) {
+        return positionRepository.findAllByUserIdOrderByExchangeAscSymbolAsc(userId).stream()
+                .filter(position -> exchange == null || exchange.equals(position.getExchange()))
+                .map(position -> safe(position.getQuantity()).abs().multiply(safe(position.getAverageEntryPrice())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal totalOpenOrderExposure(Long userId, String exchange) {
+        List<LiveOrderEntity> openOrders = exchange == null
+                ? orderRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
+                        .filter(order -> OPEN_STATUSES.contains(order.getStatus()))
+                        .toList()
+                : orderRepository.findAllByUserIdAndExchangeAndStatusIn(userId, exchange, OPEN_STATUSES);
+        return openOrders.stream()
+                .map(this::orderExposure)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal totalAcceptedDailyNotional(Long userId, Long sessionId) {
+        Instant dayStart = LocalDate.now(ZoneOffset.UTC).atStartOfDay().toInstant(ZoneOffset.UTC);
+        List<LiveOrderEntity> dailyOrders = sessionId == null
+                ? orderRepository.findAllByUserIdOrderByCreatedAtDesc(userId).stream()
+                        .filter(order -> DAILY_NOTIONAL_STATUSES.contains(order.getStatus()))
+                        .filter(order -> !order.getCreatedAt().isBefore(dayStart))
+                        .toList()
+                : orderRepository.findAllByUserIdAndSessionIdAndStatusInAndCreatedAtGreaterThanEqual(
+                        userId, sessionId, DAILY_NOTIONAL_STATUSES, dayStart);
+        return dailyOrders.stream()
+                .map(this::orderExposure)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal totalRealizedIntradayLoss(Long userId, String exchange) {
+        return positionRepository.findAllByUserIdOrderByExchangeAscSymbolAsc(userId).stream()
+                .filter(position -> exchange == null || exchange.equals(position.getExchange()))
+                .map(position -> safe(position.getRealizedPnl()))
+                .filter(realizedPnl -> realizedPnl.compareTo(BigDecimal.ZERO) < 0)
+                .map(BigDecimal::abs)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal orderExposure(LiveOrderEntity order) {
+        BigDecimal price = order.getExecutedPrice() != null ? order.getExecutedPrice() : order.getRequestedPrice();
+        if (price == null) {
+            return BigDecimal.ZERO;
+        }
+        return safe(order.getQuantity()).multiply(price);
+    }
+
+    private BigDecimal safe(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
     }
 
     private LiveOrderResponse rejectOrder(LiveOrderEntity order, String reason) {

--- a/backend/java/src/main/java/com/example/back/release/ReleaseInfo.java
+++ b/backend/java/src/main/java/com/example/back/release/ReleaseInfo.java
@@ -1,8 +1,8 @@
 package com.example.back.release;
 
 public final class ReleaseInfo {
-    public static final String VERSION = "0.9.5-alpha.1";
-    public static final String RELEASE_NAME = "Backtest Diagnostics & Strategy Report";
+    public static final String VERSION = "0.9.6-alpha.1";
+    public static final String RELEASE_NAME = "Live Risk Hardening & Release Evidence";
 
     private ReleaseInfo() {
     }

--- a/backend/java/src/main/java/com/example/back/runs/service/RunOrchestrationService.java
+++ b/backend/java/src/main/java/com/example/back/runs/service/RunOrchestrationService.java
@@ -54,7 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RunOrchestrationService {
 
-    private static final String DEFAULT_ENGINE_VERSION = "python-execution-engine/0.9.5-alpha.1";
+    private static final String DEFAULT_ENGINE_VERSION = "python-execution-engine/0.9.6-alpha.1";
     private static final String PYTHON_EXECUTE_ENDPOINT = "/internal/runs/execute";
     private static final String STRATEGY_REPORT_SAFETY_NOTE = "This report is for alpha research and validation only. "
             + "It is not financial advice and does not certify production trading readiness.";

--- a/backend/java/src/main/java/com/example/back/strategies/service/StrategyFileService.java
+++ b/backend/java/src/main/java/com/example/back/strategies/service/StrategyFileService.java
@@ -56,7 +56,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class StrategyFileService {
 
     private static final String DEFAULT_STRATEGY_TYPE = "BACKTEST";
-    private static final String DEFAULT_ENGINE_VERSION = "python-execution-engine/0.9.5-alpha.1";
+    private static final String DEFAULT_ENGINE_VERSION = "python-execution-engine/0.9.6-alpha.1";
     private static final Pattern STRATEGY_KEY_PATTERN = Pattern.compile("[^a-z0-9-]+");
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
     };

--- a/backend/java/src/main/resources/application.yml
+++ b/backend/java/src/main/resources/application.yml
@@ -77,6 +77,9 @@ live:
     default-max-order-notional: ${LIVE_TRADING_DEFAULT_MAX_ORDER_NOTIONAL:100.00000000}
     default-max-position-notional: ${LIVE_TRADING_DEFAULT_MAX_POSITION_NOTIONAL:500.00000000}
     default-max-daily-notional: ${LIVE_TRADING_DEFAULT_MAX_DAILY_NOTIONAL:1000.00000000}
+    default-max-daily-loss-notional: ${LIVE_TRADING_DEFAULT_MAX_DAILY_LOSS_NOTIONAL:250.00000000}
+    max-allowed-slippage-percent: ${LIVE_TRADING_MAX_ALLOWED_SLIPPAGE_PERCENT:2.00000000}
+    max-market-data-age-seconds: ${LIVE_TRADING_MAX_MARKET_DATA_AGE_SECONDS:60}
     max-failed-orders-before-circuit-breaker: ${LIVE_TRADING_MAX_FAILED_ORDERS_BEFORE_CIRCUIT_BREAKER:3}
     max-rejected-orders-before-circuit-breaker: ${LIVE_TRADING_MAX_REJECTED_ORDERS_BEFORE_CIRCUIT_BREAKER:10}
     binance:

--- a/backend/java/src/test/java/com/example/back/controller/HealthControllerTest.java
+++ b/backend/java/src/test/java/com/example/back/controller/HealthControllerTest.java
@@ -43,6 +43,9 @@ class HealthControllerTest {
                 new BigDecimal("100.00000000"),
                 new BigDecimal("500.00000000"),
                 new BigDecimal("1000.00000000"),
+                new BigDecimal("250.00000000"),
+                new BigDecimal("2.00000000"),
+                60,
                 3,
                 10,
                 null
@@ -79,7 +82,7 @@ class HealthControllerTest {
         mockMvc.perform(get("/api/readiness"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status", is("ready")))
-            .andExpect(jsonPath("$.apiVersion", is("0.9.5-alpha.1")))
+            .andExpect(jsonPath("$.apiVersion", is("0.9.6-alpha.1")))
             .andExpect(jsonPath("$.database", is("ok")))
             .andExpect(jsonPath("$.realOrderSubmissionEnabled", is(false)));
     }
@@ -89,9 +92,9 @@ class HealthControllerTest {
         PythonReadinessResponse response = new PythonReadinessResponse();
         response.setStatus("ready");
         response.setService("python-parser");
-        response.setParserVersion("0.9.5-alpha.1");
+        response.setParserVersion("0.9.6-alpha.1");
         response.setDatabase("ok");
-        response.setEngineVersion("python-execution-engine/0.9.5-alpha.1");
+        response.setEngineVersion("python-execution-engine/0.9.6-alpha.1");
         response.setInternalAuthConfigured("configured");
         when(pythonParserClient.getReadiness()).thenReturn(response);
 

--- a/backend/java/src/test/java/com/example/back/imports/client/PythonParserClientContractTest.java
+++ b/backend/java/src/test/java/com/example/back/imports/client/PythonParserClientContractTest.java
@@ -92,7 +92,7 @@ class PythonParserClientContractTest {
                               }
                             ]
                           },
-                          "engineVersion": "python-execution-engine/0.9.5-alpha.1",
+                          "engineVersion": "python-execution-engine/0.9.6-alpha.1",
                           "runId": "run-1",
                           "jobId": "job-1",
                           "correlationId": "corr-1",

--- a/backend/java/src/test/java/com/example/back/livetrading/controller/LiveTradingControllerIntegrationTest.java
+++ b/backend/java/src/test/java/com/example/back/livetrading/controller/LiveTradingControllerIntegrationTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.back.backtest.executor.PythonBacktestExecutor;
 import com.example.back.imports.client.PythonParserClient;
 import com.example.back.livetrading.entity.LiveOrderStatus;
+import com.example.back.livetrading.entity.LivePositionEntity;
+import com.example.back.livetrading.entity.LivePositionSyncStatus;
 import com.example.back.livetrading.repository.CircuitBreakerStateRepository;
 import com.example.back.livetrading.repository.KillSwitchStateRepository;
 import com.example.back.livetrading.repository.LiveExchangeCredentialRepository;
@@ -20,12 +22,15 @@ import com.example.back.livetrading.repository.LiveTradingSessionRepository;
 import com.example.back.livetrading.repository.TestnetCertificationReportRepository;
 import com.example.back.livetrading.service.ExchangeBalanceSnapshot;
 import com.example.back.livetrading.service.ExchangeCredentials;
+import com.example.back.livetrading.service.ExchangePriceSnapshot;
 import com.example.back.livetrading.service.ExchangePositionSnapshot;
 import com.example.back.livetrading.service.LiveExchangeAdapter;
 import com.example.back.livetrading.service.LiveOrderRequest;
 import com.example.back.livetrading.service.LiveOrderResult;
 import com.example.back.support.TestAuth;
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +59,9 @@ import org.springframework.beans.factory.annotation.Autowired;
         "live.trading.max-rejected-orders-before-circuit-breaker=1"
 })
 class LiveTradingControllerIntegrationTest {
+
+    private static Instant observedAt = Instant.now();
+    private static BigDecimal latestPrice = new BigDecimal("100.00000000");
 
     @Autowired
     private MockMvc mockMvc;
@@ -98,6 +106,8 @@ class LiveTradingControllerIntegrationTest {
         credentialRepository.deleteAll();
         circuitBreakerRepository.deleteAll();
         killSwitchRepository.deleteAll();
+        observedAt = Instant.now();
+        latestPrice = new BigDecimal("100.00000000");
     }
 
     @Test
@@ -196,6 +206,95 @@ class LiveTradingControllerIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("REJECTED"))
                 .andExpect(jsonPath("$.rejectedReason").value("Circuit breaker is active for exchange testx"));
+    }
+
+
+    @Test
+    void rejectsLimitOrdersOutsideSlippageGuard() throws Exception {
+        Long sessionId = createEnabledSession();
+
+        mockMvc.perform(post("/api/live/orders")
+                        .with(TestAuth.authenticatedRequest())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "sessionId": %d,
+                                  "side": "BUY",
+                                  "type": "LIMIT",
+                                  "quantity": 0.01,
+                                  "requestedPrice": 110
+                                }
+                                """.formatted(sessionId)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("REJECTED"))
+                .andExpect(jsonPath("$.rejectedReason").value("Limit price exceeds max slippage percent 2.00000000"));
+    }
+
+    @Test
+    void rejectsOrdersWithStaleMarketDataBeforeSubmission() throws Exception {
+        Long sessionId = createEnabledSession();
+        observedAt = Instant.now().minus(2, ChronoUnit.MINUTES);
+
+        mockMvc.perform(post("/api/live/orders")
+                        .with(TestAuth.authenticatedRequest())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "sessionId": %d,
+                                  "side": "BUY",
+                                  "type": "MARKET",
+                                  "quantity": 0.01
+                                }
+                                """.formatted(sessionId)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("REJECTED"))
+                .andExpect(jsonPath("$.rejectedReason").value("Market data is stale for symbol BTCUSDT"));
+    }
+
+    @Test
+    void rejectsOrdersThatWouldExceedPortfolioExposure() throws Exception {
+        Long sessionId = createEnabledSession();
+        LivePositionEntity position = new LivePositionEntity();
+        position.setUserId(TestAuth.USER_ID);
+        position.setExchange("testx");
+        position.setSymbol("ETHUSDT");
+        position.setQuantity(new BigDecimal("4.90"));
+        position.setAverageEntryPrice(new BigDecimal("100.00000000"));
+        position.setRealizedPnl(BigDecimal.ZERO);
+        position.setUnrealizedPnl(BigDecimal.ZERO);
+        position.setSyncStatus(LivePositionSyncStatus.SYNCED);
+        positionRepository.save(position);
+
+        mockMvc.perform(post("/api/live/orders")
+                        .with(TestAuth.authenticatedRequest())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "sessionId": %d,
+                                  "side": "BUY",
+                                  "type": "MARKET",
+                                  "quantity": 0.20
+                                }
+                                """.formatted(sessionId)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("REJECTED"))
+                .andExpect(jsonPath("$.rejectedReason").value("Portfolio exposure would exceed max position limit 500.00000000"));
+    }
+
+    @Test
+    void riskStatusIncludesExposureSummary() throws Exception {
+        createEnabledSession();
+
+        mockMvc.perform(get("/api/live/risk/status")
+                        .with(TestAuth.authenticatedRequest()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.syncedPositionExposure").exists())
+                .andExpect(jsonPath("$.openOrderExposure").exists())
+                .andExpect(jsonPath("$.acceptedDailyNotional").exists())
+                .andExpect(jsonPath("$.realizedIntradayLoss").exists())
+                .andExpect(jsonPath("$.maxAllowedDailyLoss").value(250.00000000))
+                .andExpect(jsonPath("$.maxAllowedSlippagePercent").value(2.00000000))
+                .andExpect(jsonPath("$.maxMarketDataAgeSeconds").value(60));
     }
 
     @Test
@@ -367,7 +466,12 @@ class LiveTradingControllerIntegrationTest {
 
                 @Override
                 public Optional<BigDecimal> getLatestPrice(String symbol) {
-                    return Optional.of(new BigDecimal("100.00000000"));
+                    return Optional.of(latestPrice);
+                }
+
+                @Override
+                public Optional<ExchangePriceSnapshot> getLatestPriceSnapshot(String symbol) {
+                    return Optional.of(new ExchangePriceSnapshot(latestPrice, observedAt));
                 }
 
                 @Override

--- a/backend/java/src/test/java/com/example/back/livetrading/startup/LiveTradingStartupSafetyCheckTest.java
+++ b/backend/java/src/test/java/com/example/back/livetrading/startup/LiveTradingStartupSafetyCheckTest.java
@@ -84,6 +84,9 @@ class LiveTradingStartupSafetyCheckTest {
                 new BigDecimal("100"),
                 new BigDecimal("500"),
                 new BigDecimal("1000"),
+                new BigDecimal("250"),
+                new BigDecimal("2"),
+                60,
                 3,
                 10,
                 new LiveTradingProperties.Binance(

--- a/backend/python/parser/main.py
+++ b/backend/python/parser/main.py
@@ -63,7 +63,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(
         title="TradeLab Python Parser API",
-        version="0.9.5-alpha.1",
+        version="0.9.6-alpha.1",
         description="Internal API for candle imports, strategy validation, and strategy execution.",
         docs_url="/docs",
         redoc_url="/redoc",
@@ -201,7 +201,7 @@ def create_app() -> FastAPI:
         return ReadinessResponse(
             status="ready" if database_status == "ok" else "degraded",
             service="python-parser",
-            parserVersion="0.9.5-alpha.1",
+            parserVersion="0.9.6-alpha.1",
             database=database_status,
             engineVersion=ENGINE_VERSION,
             internalAuthConfigured=internal_auth_status,

--- a/backend/python/parser/runs/services/strategy_execution_service.py
+++ b/backend/python/parser/runs/services/strategy_execution_service.py
@@ -17,7 +17,7 @@ from parser.services.backtest_diagnostics import calculate_backtest_diagnostics
 logger = logging.getLogger(__name__)
 
 
-ENGINE_VERSION = "python-execution-engine/0.9.5-alpha.1"
+ENGINE_VERSION = "python-execution-engine/0.9.6-alpha.1"
 
 
 class StrategyExecutionService:

--- a/backend/python/parser/strategies/dto/strategy_validation_dto.py
+++ b/backend/python/parser/strategies/dto/strategy_validation_dto.py
@@ -53,7 +53,7 @@ class StrategyValidationResponse(BaseModel):
         description="Resolved strategy metadata.",
     )
     engine_version: str = Field(
-        default="python-execution-engine/0.9.5-alpha.1",
+        default="python-execution-engine/0.9.6-alpha.1",
         alias="engineVersion",
         serialization_alias="engineVersion",
         description="Python engine version used for compatibility validation.",

--- a/backend/python/tests/test_readiness.py
+++ b/backend/python/tests/test_readiness.py
@@ -57,6 +57,6 @@ def test_readiness_does_not_expose_internal_secret(monkeypatch) -> None:
 
     assert response_start["status"] == 200
     assert payload["service"] == "python-parser"
-    assert payload["parserVersion"] == "0.9.5-alpha.1"
+    assert payload["parserVersion"] == "0.9.6-alpha.1"
     assert "secret" not in payload
     assert "internalAuthConfigured" in payload

--- a/docs/api.md
+++ b/docs/api.md
@@ -452,6 +452,20 @@ Rejected orders сохраняются со `status=REJECTED` и `rejectedReason
 }
 ```
 
+<h3 align="center">GET `/api/live/risk/status`</h3>
+
+Returns live risk state and release `v0.9.6-alpha.1` exposure evidence fields:
+
+- `killSwitchActive`, `killSwitchReason`, `killSwitchActivatedAt`
+- `circuitBreakers`
+- `syncedPositionExposure`
+- `openOrderExposure`
+- `acceptedDailyNotional`
+- `realizedIntradayLoss`
+- `maxAllowedDailyLoss`
+- `maxAllowedSlippagePercent`
+- `maxMarketDataAgeSeconds`
+
 <h3 align="center">GET `/api/live/orders`</h3>
 
 Возвращает live orders текущего пользователя.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -399,6 +399,8 @@ Manual live execution boundary с per-session risk limits.
 - `max_position_notional`
 - `max_daily_notional`
 - `symbol_whitelist`
+
+`v0.9.6-alpha.1` uses these caps together with runtime configuration for max daily loss, max slippage percent, and max market-data age. No new table columns are required for those response-only guards.
 - `created_at`
 - `updated_at`
 

--- a/docs/database/migrations.md
+++ b/docs/database/migrations.md
@@ -1,6 +1,6 @@
 # Database Migration Workflow
 
-Target release: `v0.9.5-alpha.1`
+Target release: `v0.9.6-alpha.1`
 
 Trade360Lab now includes a Flyway migration baseline for Java-managed schema evolution while keeping existing local startup simple.
 

--- a/docs/live-risk-hardening-v0.9.6.md
+++ b/docs/live-risk-hardening-v0.9.6.md
@@ -1,0 +1,34 @@
+# v0.9.6-alpha.1 Live Risk Hardening
+
+`v0.9.6-alpha.1` keeps real order submission disabled by default and strengthens pre-submit live-order guards. These controls reduce unsafe adapter submissions; they are not production exchange certification.
+
+## Guards
+
+- Kill switch and circuit breaker gates must be clear.
+- Session must be `ENABLED` and credentials must be active and valid.
+- Quantity, limit price, symbol whitelist, per-order notional, duplicate open order, and balance checks still run before adapter submission.
+- Portfolio exposure combines synced position exposure, open-order exposure, and the candidate order notional before comparing with the session max position notional.
+- Daily notional combines same-day submitted/accepted/filled order exposure with the candidate order notional before comparing with the session max daily notional.
+- Realized intraday loss uses synced negative realized PnL and rejects once it exceeds `LIVE_TRADING_DEFAULT_MAX_DAILY_LOSS_NOTIONAL`.
+- Limit-order slippage compares requested price with the latest market price and rejects when the configured percent is exceeded.
+- Market-data staleness rejects price snapshots older than `LIVE_TRADING_MAX_MARKET_DATA_AGE_SECONDS`.
+
+## Configuration
+
+- `LIVE_TRADING_DEFAULT_MAX_DAILY_LOSS_NOTIONAL` default: `250.00000000`
+- `LIVE_TRADING_MAX_ALLOWED_SLIPPAGE_PERCENT` default: `2.00000000`
+- `LIVE_TRADING_MAX_MARKET_DATA_AGE_SECONDS` default: `60`
+
+## Operator evidence
+
+`GET /api/live/risk/status` now includes exposure and threshold fields for release validation:
+
+- `syncedPositionExposure`
+- `openOrderExposure`
+- `acceptedDailyNotional`
+- `realizedIntradayLoss`
+- `maxAllowedDailyLoss`
+- `maxAllowedSlippagePercent`
+- `maxMarketDataAgeSeconds`
+
+Every rejected order persists its `rejectedReason` and emits a risk audit event.

--- a/docs/openapi-artifacts.md
+++ b/docs/openapi-artifacts.md
@@ -1,15 +1,15 @@
 <h1 align="center">OpenAPI-артефакты релиза</h1>
 
-Релиз `v0.9.5-alpha.1` экспортирует API-контракты как build artifacts после запуска Java API и Python parser.
+Релиз `v0.9.6-alpha.1` экспортирует API-контракты как build artifacts после запуска Java API и Python parser.
 
 ```bash
 docker compose up --build -d
-scripts/export-openapi-artifacts.sh 0.9.5-alpha.1
+scripts/export-openapi-artifacts.sh 0.9.6-alpha.1
 ```
 
 Принятое расположение артефактов:
 
-- `artifacts/openapi-java-v0.9.5-alpha.1.json`
-- `artifacts/openapi-python-v0.9.5-alpha.1.json`
+- `artifacts/openapi-java-v0.9.6-alpha.1.json`
+- `artifacts/openapi-python-v0.9.6-alpha.1.json`
 
 Скрипт читает `JAVA_OPENAPI_URL` и `PYTHON_OPENAPI_URL`, если нужны нестандартные host/port, и ретраит загрузку, пока сервисы становятся ready.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,12 +1,12 @@
 <h1 align="center">Чеклист альфа-релиза</h1>
 
-Целевой релиз: `v0.9.5-alpha.1`
+Целевой релиз: `v0.9.6-alpha.1`
 
 <h2 align="center">Область релиза</h2>
-- [x] Выбраны тег и версия релиза: `0.9.5-alpha.1`
+- [x] Выбраны тег и версия релиза: `0.9.6-alpha.1`
 - [x] Журнал изменений обновлен для этого релиза
 - [x] Черновик release notes подготовлен
-- [ ] GitHub Release создан из тега `v0.9.5-alpha.1`
+- [ ] GitHub Release создан из тега `v0.9.6-alpha.1`
 
 <h2 align="center">Качество кода</h2>
 - [ ] Frontend: `npm --prefix frontend ci`
@@ -32,15 +32,25 @@
 - [ ] Frontend `/runs/[id]` показывает Strategy Report и graceful missing state.
 - [ ] Frontend `/compare` сравнивает max drawdown, win rate, profit factor, trade count, diagnostics status, warnings count, and stability status.
 
+
+<h2 align="center">Live risk hardening validation</h2>
+- [ ] Portfolio exposure summary reflects current synced positions and open orders.
+- [ ] Cross-symbol exposure blocks orders above session max position notional.
+- [ ] Session daily notional guard includes accepted/filled/submitted same-day orders.
+- [ ] Realized intraday loss guard blocks new orders after configured loss threshold.
+- [ ] Limit-order slippage guard rejects prices outside the configured percentage from latest market price.
+- [ ] Market-data staleness guard rejects stale price snapshots before adapter submission.
+- [ ] Risk audit shows explicit rejection reasons for exposure, daily notional, loss, slippage, and stale market data.
+
 <h2 align="center">Проверка артефактов</h2>
 - [ ] `strategy-report-{runId}.json` создается для успешного run.
 - [ ] Report artifact содержит run id, strategy id/version id, dataset id, metrics, diagnostics, warnings, generatedAt.
 - [ ] Report artifact содержит safety note.
 - [ ] `GET /api/runs/{id}/artifacts` показывает strategy report artifact.
 - [ ] `GET /api/runs/{id}/artifacts/{artifactId}/download` скачивает report JSON.
-- [ ] `scripts/export-openapi-artifacts.sh 0.9.5-alpha.1` записывает:
-  - `artifacts/openapi-java-v0.9.5-alpha.1.json`
-  - `artifacts/openapi-python-v0.9.5-alpha.1.json`
+- [ ] `scripts/export-openapi-artifacts.sh 0.9.6-alpha.1` записывает:
+  - `artifacts/openapi-java-v0.9.6-alpha.1.json`
+  - `artifacts/openapi-python-v0.9.6-alpha.1.json`
 
 <h2 align="center">Проверка запуска</h2>
 - [ ] `docker compose config -q`

--- a/docs/release-notes-v0.9.6-alpha.1.md
+++ b/docs/release-notes-v0.9.6-alpha.1.md
@@ -1,0 +1,40 @@
+# v0.9.6-alpha.1 - Live Risk Hardening & Release Evidence
+
+Release date: 2026-06-03
+
+## What changed
+
+- Aligned monorepo, frontend, Java API, Python parser, diagnostics scripts, smoke tests, and release metadata on `0.9.6-alpha.1`.
+- Hardened live-order pre-submit risk checks with portfolio exposure, daily notional, realized-loss, slippage, and market-data staleness guards.
+- Added live risk status exposure fields so operators can see synced position exposure, open-order exposure, accepted daily notional, realized loss, and configured guard thresholds.
+- Updated release checklist and documentation for `v0.9.6-alpha.1` validation evidence.
+- Updated alpha release workflow copy to describe the current release scope.
+
+## Contract
+
+Live order placement remains guarded before adapter submission. Rejected orders are persisted with explicit `rejectedReason` values and corresponding risk audit events. `GET /api/live/risk/status` now includes additional optional summary fields:
+
+- `syncedPositionExposure`
+- `openOrderExposure`
+- `acceptedDailyNotional`
+- `realizedIntradayLoss`
+- `maxAllowedDailyLoss`
+- `maxAllowedSlippagePercent`
+- `maxMarketDataAgeSeconds`
+
+## Safety
+
+- Real order submission remains disabled by default.
+- Live risk guards reduce unsafe submissions but do not certify production exchange trading.
+- Testnet/backtest validation is not production exchange certification.
+- Strategy reports and diagnostics remain research artifacts, not trading signals.
+
+## Validation notes
+
+- Validate frontend, Python, Java, Docker smoke, OpenAPI export, and diagnostics bundle commands from the release checklist.
+- Validate live risk rejection reasons for exposure, daily notional, realized loss, stale market data, and slippage.
+- Validate risk audit visibility for every rejected live order.
+
+## Rollback notes
+
+No database migration is required for this release. Rollback can redeploy `v0.9.5-alpha.1`; new risk status fields are response-only and rejected orders remain auditable through existing `rejected_reason` and risk event records.

--- a/docs/runbooks/diagnostics-collection.md
+++ b/docs/runbooks/diagnostics-collection.md
@@ -1,6 +1,6 @@
 # Diagnostics Collection
 
-Target release: `v0.9.5-alpha.1`
+Target release: `v0.9.6-alpha.1`
 
 Use the diagnostics collector when validating alpha releases or attaching troubleshooting context to GitHub Issues.
 

--- a/docs/runbooks/live-trading-audit-export.md
+++ b/docs/runbooks/live-trading-audit-export.md
@@ -1,6 +1,6 @@
 # Live Trading Audit Export Runbook
 
-Target release: `v0.9.5-alpha.1`
+Target release: `v0.9.6-alpha.1`
 
 Live trading audit exports are for alpha validation and troubleshooting. They do not enable production order submission.
 

--- a/docs/runbooks/local-backup-restore.md
+++ b/docs/runbooks/local-backup-restore.md
@@ -1,6 +1,6 @@
 # Local Backup And Restore
 
-Target release: `v0.9.5-alpha.1`
+Target release: `v0.9.6-alpha.1`
 
 These scripts are for local alpha PostgreSQL recovery workflows using Docker Compose defaults.
 

--- a/docs/runbooks/release-rollback.md
+++ b/docs/runbooks/release-rollback.md
@@ -1,6 +1,6 @@
 <h1 align="center">Rollback релиза</h1>
 
-Целевой релиз: `v0.9.5-alpha.1`
+Целевой релиз: `v0.9.6-alpha.1`
 
 <h2 align="center">Триггеры</h2>
 
@@ -14,7 +14,7 @@
 1. Оставить `LIVE_TRADING_REAL_ORDER_SUBMISSION_ENABLED=false`.
 2. Объявить rollback в release channel.
 3. Остановить текущий стек командой `docker compose down`.
-4. Повторно развернуть последний известный исправный тег, сейчас это `v0.9.2-alpha.1`.
+4. Повторно развернуть последний известный исправный тег, сейчас это `v0.9.5-alpha.1`.
 5. Выполнить `docker compose config -q`.
 6. Выполнить `scripts/docker-compose-smoke.sh`.
 7. Проверить:

--- a/docs/runbooks/testnet-certification-report-review.md
+++ b/docs/runbooks/testnet-certification-report-review.md
@@ -1,6 +1,6 @@
 # Testnet Certification Report Review
 
-Target release: `v0.9.5-alpha.1`
+Target release: `v0.9.6-alpha.1`
 
 Testnet certification reports persist the result of a Binance testnet drill. They are not production exchange certification and do not imply production readiness.
 

--- a/frontend/app/live/page.tsx
+++ b/frontend/app/live/page.tsx
@@ -99,6 +99,13 @@ type LiveRiskStatus = {
   killSwitchActive: boolean;
   killSwitchReason?: string | null;
   circuitBreakers: { exchange: string; active: boolean; reason?: string | null }[];
+  syncedPositionExposure?: number | null;
+  openOrderExposure?: number | null;
+  acceptedDailyNotional?: number | null;
+  realizedIntradayLoss?: number | null;
+  maxAllowedDailyLoss?: number | null;
+  maxAllowedSlippagePercent?: number | null;
+  maxMarketDataAgeSeconds?: number | null;
 };
 
 type LiveRiskEvent = {
@@ -461,8 +468,16 @@ export default function LiveTradingPage() {
               <Metric label="Credentials" value={health?.credentialsValid ? "Valid" : "Missing"} />
               <Metric label="Submission" value={health?.realOrderSubmissionEnabled ? "Enabled" : "Disabled"} />
             </div>
+            <div className="mt-3 grid gap-3 md:grid-cols-4">
+              <Metric label="Position exposure" value={formatMoney(risk?.syncedPositionExposure)} />
+              <Metric label="Open order exposure" value={formatMoney(risk?.openOrderExposure)} />
+              <Metric label="Daily notional" value={formatMoney(risk?.acceptedDailyNotional)} />
+              <Metric label="Realized loss" value={`${formatMoney(risk?.realizedIntradayLoss)} / ${formatMoney(risk?.maxAllowedDailyLoss)}`} />
+              <Metric label="Slippage guard" value={`${risk?.maxAllowedSlippagePercent ?? "-"}% max`} />
+              <Metric label="Market data age" value={`${risk?.maxMarketDataAgeSeconds ?? "-"}s max`} />
+            </div>
             <div className="mt-4 rounded-[16px] border border-status-warning/30 bg-status-warning/10 px-4 py-3 text-xs text-status-warning">
-              Real order submission remains disabled by default. Testnet certification does not imply production readiness.
+              Real order submission remains disabled by default. Exposure, slippage, realized-loss, and stale-data guards reduce unsafe submissions but do not certify production readiness.
             </div>
           </SurfaceCard>
 
@@ -561,6 +576,7 @@ export default function LiveTradingPage() {
                   <TableCell>{position.exchange}</TableCell>
                   <TableCell>{position.symbol}</TableCell>
                   <TableCell>{Number(position.quantity).toLocaleString("en-US", { maximumFractionDigits: 8 })}</TableCell>
+                  <TableCell>{formatMoney(position.realizedPnl)}</TableCell>
                 </TableRow>
               ))}
             </LiveTable>

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -25,7 +25,7 @@ async function seedSession(page: Page) {
       json: {
         status: "ready",
         service: "java-api",
-        apiVersion: "0.9.5-alpha.1",
+        apiVersion: "0.9.6-alpha.1",
         database: "ok",
         migrationStatus: "flyway-baseline-present",
         liveTradingMode: "guarded-alpha",
@@ -39,9 +39,9 @@ async function seedSession(page: Page) {
       json: {
         status: "ready",
         service: "python-parser",
-        parserVersion: "0.9.5-alpha.1",
+        parserVersion: "0.9.6-alpha.1",
         database: "ok",
-        engineVersion: "python-execution-engine/0.9.5-alpha.1",
+        engineVersion: "python-execution-engine/0.9.6-alpha.1",
         internalAuthConfigured: "configured",
       },
     })
@@ -111,5 +111,5 @@ test("live trading safety and service health pages render", async ({ page }) => 
 
   await gotoReady(page, "/settings");
   await expect(page.getByText("Readiness Dashboard")).toBeVisible();
-  await expect(page.getByText("v0.9.5-alpha.1").first()).toBeVisible();
+  await expect(page.getByText("v0.9.6-alpha.1").first()).toBeVisible();
 });

--- a/frontend/lib/release.ts
+++ b/frontend/lib/release.ts
@@ -1,4 +1,4 @@
 export const releaseInfo = {
-  version: "0.9.5-alpha.1",
-  name: "Backtest Diagnostics & Strategy Report",
+  version: "0.9.6-alpha.1",
+  name: "Live Risk Hardening & Release Evidence",
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradelab_app",
-  "version": "0.9.5-alpha.1",
+  "version": "0.9.6-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradelab_app",
-      "version": "0.9.5-alpha.1",
+      "version": "0.9.6-alpha.1",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradelab_app",
-  "version": "0.9.5-alpha.1",
+  "version": "0.9.6-alpha.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradelab",
-  "version": "0.9.2-alpha.1",
+  "version": "0.9.6-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradelab",
-      "version": "0.9.2-alpha.1"
+      "version": "0.9.6-alpha.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradelab",
-  "version": "0.9.2-alpha.1",
+  "version": "0.9.6-alpha.1",
   "private": true,
   "scripts": {
     "dev": "npm --prefix frontend run dev",

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -21,7 +21,7 @@ write_json() {
   fi
 }
 
-printf '{"release":"0.9.2-alpha.1","frontendUrl":"%s","javaUrl":"%s","pythonUrl":"%s"}\n' "$FRONTEND_URL" "$JAVA_URL" "$PYTHON_URL" > "$OUT/app-version.json"
+printf '{"release":"0.9.6-alpha.1","frontendUrl":"%s","javaUrl":"%s","pythonUrl":"%s"}\n' "$FRONTEND_URL" "$JAVA_URL" "$PYTHON_URL" > "$OUT/app-version.json"
 write_json java-health.json "$JAVA_URL/api/health"
 write_json java-readiness.json "$JAVA_URL/api/readiness"
 write_json python-health.json "$PYTHON_URL/health"


### PR DESCRIPTION
# Что сделано
- Добавлены defaultMaxDailyLossNotional, maxAllowedSlippagePercent, maxMarketDataAgeSeconds в LiveTradingProperties с настройками в application.yml.
- Ужесточены проверки в LiveTradingService: свежесть данных, проскальзывание, экспозиция (позиции + ордера + заявка), дневной номинал и реализованный убыток. Добавлены вспомогательные 
- Введён ExchangePriceSnapshot и getLatestPriceSnapshot в LiveExchangeAdapter (цена + 
- Расширен LiveRiskStatusResponse новыми полями. Добавлены методы в LiveOrderRepository и 
- Обновлён фронтенд: отображение метрик экспозиции/порогов и причин отклонения. Добавлены e2e и интеграционные 
- Обновлены версии в Java, Python, фронтенде, скриптах и документации до 0.9.6-alpha.1. Миграция БД не требуется (только проверки в ответе).